### PR TITLE
disconnect時の処理の追加

### DIFF
--- a/libs/dealer.js
+++ b/libs/dealer.js
@@ -343,7 +343,6 @@ class Dealer {
       this._disconnected = true
       this._resetCountdown()
       this._io.to(this._worldId).emit('notice_disconnect', {})
-      socket.leave(this._worldId)
     })
   }
 }


### PR DESCRIPTION
ref #63 

クライアントからのdisconnectを取得した場合の処理を追加。
ブラウザのリロードした側にモーダルを表示する対策として、新しく`this._disconnected`を定義し、`this._disconnected`が`true`の場合にも`notice_disconnect`をemitするように実装。
disconnectされると暗黙的に`socket.leave`され、ルームから排除されるため`socket.leave(this._worldId)`は削除。
