### PR TITLE
募集APIの修正

### DIFF
--- a/controllers/world-controller.js
+++ b/controllers/world-controller.js
@@ -7,9 +7,8 @@ class WorldController {
     const errors = validationResult(req)
     if (!errors.isEmpty()) { return res.status(400).json({ msg: 'ぼしゅうにしっぱいしました' }) }
 
-    const worldId = world.create()
-    const recruit = Number(req.query.recruit)
-    const role = recruit === PLAYER_PEKORA ? PLAYER_BAIKINKUN : PLAYER_PEKORA
+    const worldId = world.create(req.query.isPublic)
+    const role = Number(req.query.role) === PLAYER_PEKORA ? PLAYER_BAIKINKUN : PLAYER_PEKORA
 
     const token = world.recruit(worldId, role)
     return res.status(200).json({ worldId, token, role })

--- a/libs/world.js
+++ b/libs/world.js
@@ -43,7 +43,7 @@ class World {
   /**
    * ワールドの作成（初期化処理）
    */
-  create () {
+  create (isPublic) {
     const id = Helpers.generateId(6)
     this._states.push({
       id,
@@ -56,7 +56,8 @@ class World {
       word: new Word(),
       dealer: null,
       createdAt: Helpers.getTimestamp(),
-      status: worldStatus.initialized
+      status: worldStatus.initialized,
+      isPublic
     })
     return id
   }

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,7 +13,8 @@ router.get('/rules', rulesController.getRules.bind(rulesController))
  * 募集
  */
 router.get('/recruit', [
-  check('recruit').not().isEmpty().isIn([1, 2])
+  check('role').not().isEmpty().isIn([1, 2]),
+  check('isPublic').not().isEmpty().isBoolean()
 ], worldController.recruit.bind(worldController))
 
 /**

--- a/tests/world-join.spec.js
+++ b/tests/world-join.spec.js
@@ -8,7 +8,7 @@ describe('world join api', () => {
       expect(res.statusCode).toBe(200)
     })
     test('body (validity: true)', async () => {
-      const recruit = await request(server).get('/api/v1/recruit').query({ recruit: 1 })
+      const recruit = await request(server).get('/api/v1/recruit').query({ role: 1, isPublic: true })
       const worldId = await recruit.body.worldId
       const res = await request(server).get('/api/v1/join').query({ worldId })
       expect(res.body).toMatchObject({

--- a/tests/world-recruit.spec.js
+++ b/tests/world-recruit.spec.js
@@ -3,12 +3,16 @@ const server = require('../app')
 
 describe('world recruit api', () => {
   describe('normal', () => {
+    const req = {
+      role: 1,
+      isPublic: true
+    }
     test('status', async () => {
-      const res = await request(server).get('/api/v1/recruit').query({ recruit: 1 })
+      const res = await request(server).get('/api/v1/recruit').query(req)
       expect(res.statusCode).toBe(200)
     })
     test('body', async () => {
-      const res = await request(server).get('/api/v1/recruit').query({ recruit: 1 })
+      const res = await request(server).get('/api/v1/recruit').query(req)
       expect(res.body).toMatchObject({
         worldId: expect.any(String),
         token: expect.any(String),
@@ -17,12 +21,16 @@ describe('world recruit api', () => {
     })
   })
   describe('exception', () => {
+    const req = {
+      role: 3,
+      isPublic: true
+    }
     test('status', async () => {
-      const res = await request(server).get('/api/v1/recruit').query({ recruit: 3 })
+      const res = await request(server).get('/api/v1/recruit').query(req)
       expect(res.statusCode).toBe(400)
     })
     test('body', async () => {
-      const res = await request(server).get('/api/v1/recruit').query({ recruit: 3 })
+      const res = await request(server).get('/api/v1/recruit').query(req)
       expect(res.body).toMatchObject({
         msg: 'ぼしゅうにしっぱいしました'
       })

--- a/tests/world-states.spec.js
+++ b/tests/world-states.spec.js
@@ -12,7 +12,7 @@ describe('world states api', () => {
       expect(res.body).toMatchObject([])
     })
     test('body', async () => {
-      await request(server).get('/api/v1/recruit').query({ recruit: 1 })
+      await request(server).get('/api/v1/recruit').query({ role: 1, isPublic: true })
       const res = await request(server).get('/api/v1/states')
       expect(res.body[0]).toMatchObject({
         id: expect.any(String),


### PR DESCRIPTION
close #70 

募集APIを`/recruit/public`と`/recruit/private`に分けて実装しました