### PR TITLE
検索APIの修正

### DIFF
--- a/libs/world.js
+++ b/libs/world.js
@@ -180,7 +180,7 @@ class World {
       slicedStates.forEach((state) => {
         worlds.push({
           id: state.id,
-          role: state.tokens[PLAYER_PEKORA] ? PLAYER_BAIKINKUN : PLAYER_PEKORA
+          role: state.players[PLAYER_PEKORA] ? PLAYER_BAIKINKUN : PLAYER_PEKORA
         })
       })
     }

--- a/routes/api.js
+++ b/routes/api.js
@@ -78,8 +78,9 @@ router.get('/join', [
  * 検索
  */
 router.get('/search', [
-  check('page').not().isEmpty().isInt({ min: 1 }),
-  check('limit').not().isEmpty().isInt({ min: 1, max: 20 })
+  verifyToken,
+  query('page').not().isEmpty().isInt({ min: 1 }),
+  query('limit').not().isEmpty().isInt({ min: 1, max: 20 })
 ], worldController.search.bind(worldController))
 
 module.exports = router

--- a/tests/world-search.spec.js
+++ b/tests/world-search.spec.js
@@ -1,15 +1,18 @@
 const request = require('supertest')
 const server = require('../app')
+const { PLAYER_PEKORA } = require('../libs/constants')
 
 describe('world search api', () => {
   describe('normal', () => {
     test('status', async () => {
-      const res = await request(server).get('/api/v1/search').query({ page: 1, limit: 10 })
+      const token = (await request(server).post('/api/v1/login').send({ userId: 'foo', password: 'password' })).body.token
+      const res = await request(server).get('/api/v1/search').set('Authorization', `Bearer ${token}`).query({ page: 1, limit: 10 })
       expect(res.statusCode).toBe(200)
     })
     test('body', async () => {
-      await request(server).get('/api/v1/recruit').query({ role: 1, isPublic: true })
-      const res = await request(server).get('/api/v1/search').query({ page: 1, limit: 10 })
+      const token = (await request(server).post('/api/v1/login').send({ userId: 'foo', password: 'password' })).body.token
+      await request(server).get('/api/v1/recruit').set('Authorization', `Bearer ${token}`).query({ role: PLAYER_PEKORA, isPublic: true })
+      const res = await request(server).get('/api/v1/search').set('Authorization', `Bearer ${token}`).query({ page: 1, limit: 10 })
       expect(res.body).toMatchObject({
         page: expect.any(Number),
         limit: expect.any(Number),
@@ -24,11 +27,13 @@ describe('world search api', () => {
   })
   describe('exception', () => {
     test('status', async () => {
-      const res = await request(server).get('/api/v1/search').query({ page: 1, limit: 21 })
+      const token = (await request(server).post('/api/v1/login').send({ userId: 'foo', password: 'password' })).body.token
+      const res = await request(server).get('/api/v1/search').set('Authorization', `Bearer ${token}`).query({ page: 1, limit: 21 })
       expect(res.statusCode).toBe(400)
     })
     test('body', async () => {
-      const res = await request(server).get('/api/v1/search').query({ page: 0, limit: 10 })
+      const token = (await request(server).post('/api/v1/login').send({ userId: 'foo', password: 'password' })).body.token
+      const res = await request(server).get('/api/v1/search').set('Authorization', `Bearer ${token}`).query({ page: 0, limit: 10 })
       expect(res.body).toMatchObject({
         msg: 'けんさくにしっぱいしました'
       })


### PR DESCRIPTION
close #119

- worldクラスの`this._states`の`tokens`キーが`players`に変更されたので対応
- express-validatorの`check`から`query`に修正
- テストに認証を追加